### PR TITLE
Add flag to allow debug messages in logs

### DIFF
--- a/ash_model_plotting/plot_ash_model_results.py
+++ b/ash_model_plotting/plot_ash_model_results.py
@@ -14,8 +14,7 @@ from ash_model_plotting import (
     AshModelResultError,
 )
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger = logging.getLogger('plot_ash_model_results')
 
 
 MODEL_TYPES = {
@@ -95,10 +94,22 @@ def main():
         help=("Path to directory to store plots (defaults to source_dir), "
               "creates directory if doesn't exist"),
         default=None)
+    parser.add_argument(
+        '--verbose',
+        help=("Print debugging messages in output"),
+        action='store_true')
     args = parser.parse_args()
+
+    if args.verbose:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    logging.basicConfig(level=log_level)
+
     plot_results(args.results, args.model_type, args.limits,
                  args.vaac_colours, args.output_dir)
 
 
 if __name__ == '__main__':
+    os.environ['PYTHONWARNINGS'] = 'ignore'
     main()

--- a/ash_model_plotting/plot_ash_model_results.py
+++ b/ash_model_plotting/plot_ash_model_results.py
@@ -104,12 +104,22 @@ def main():
         log_level = logging.DEBUG
     else:
         log_level = logging.INFO
-    logging.basicConfig(level=log_level)
+    logging.getLogger().setLevel(log_level)
 
     plot_results(args.results, args.model_type, args.limits,
                  args.vaac_colours, args.output_dir)
 
 
 if __name__ == '__main__':
+    # Suppress warning messages from Matplotlib etc
     os.environ['PYTHONWARNINGS'] = 'ignore'
+
+    # Configure logger
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
+    handler.setFormatter(formatter)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(handler)
+
+    # Run script
     main()


### PR DESCRIPTION
### Description

These commits add log messages to the output of `plot_ash_model_results`.  There is also a `--verbose` flag that can be used to include the output of DEBUG statements.

### To test

+ [ ] Calling `python ash_model_plotting/plot_ash_model_results.py test/data/VA_Tutorial_NAME_output.nc --output_dir /tmp/results` prints log messages

+ [ ] Calling `python ash_model_plotting/plot_ash_model_results.py test/data/VA_Tutorial_NAME_output.nc --output_dir /tmp/results` prints log messages, including from DEBUG