### PR TITLE
Configure logging in main() method

### DIFF
--- a/ash_model_plotting/plot_ash_model_results.py
+++ b/ash_model_plotting/plot_ash_model_results.py
@@ -24,6 +24,30 @@ MODEL_TYPES = {
 }
 
 
+def main():
+    """Prepare arguments and logging then run script."""
+    # Suppress warning messages from Matplotlib etc
+    os.environ['PYTHONWARNINGS'] = 'ignore'
+
+    # Configure logger
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
+    handler.setFormatter(formatter)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(handler)
+
+    args = parse_args()
+
+    if args.verbose:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    logging.getLogger().setLevel(log_level)
+
+    plot_results(args.results, args.model_type, args.limits,
+                 args.vaac_colours, args.output_dir)
+
+
 def plot_results(results, model_type, limits, vaac_colours, output_dir):
     """
     Plot ash model results the layers in the input_files.  Plots are made
@@ -67,8 +91,8 @@ def plot_results(results, model_type, limits, vaac_colours, output_dir):
             logger.info(f'No {attribute} data found')
 
 
-def main():
-    """Parse arguments and call plot_name_files."""
+def parse_args():
+    """Parse arguments"""
     parser = argparse.ArgumentParser(
         description='Generate plots from NAME data .txt files')
     parser.add_argument(
@@ -100,26 +124,8 @@ def main():
         action='store_true')
     args = parser.parse_args()
 
-    if args.verbose:
-        log_level = logging.DEBUG
-    else:
-        log_level = logging.INFO
-    logging.getLogger().setLevel(log_level)
-
-    plot_results(args.results, args.model_type, args.limits,
-                 args.vaac_colours, args.output_dir)
+    return args
 
 
 if __name__ == '__main__':
-    # Suppress warning messages from Matplotlib etc
-    os.environ['PYTHONWARNINGS'] = 'ignore'
-
-    # Configure logger
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
-    handler.setFormatter(formatter)
-    root_logger = logging.getLogger()
-    root_logger.addHandler(handler)
-
-    # Run script
     main()


### PR DESCRIPTION
### Description

When plot_ash_model_results is called as an installed script, the
__name__ == "__main__" block is not called.  Moving the code into the
main() method ensures that it is and so logging is configured correctly
even for the installed version.

### To test

+ [x] Checkout `master`, install with `pip -e install .`, run a `plot_ash_model_results` job and see lots of warning messages
+ [x] Checkout `logging-in-installed-script`, install, run the job and see log output and no messages
+ [x] Run all tests and confirm they still work (`pytest -vs test`)

\closes #5 